### PR TITLE
Add Cloudflare Worker fan-out proxy

### DIFF
--- a/index.html
+++ b/index.html
@@ -378,5 +378,62 @@ function exportMarkdown(){
   setTimeout(()=>URL.revokeObjectURL(url), 1000);
 }
 </script>
+
+<!-- Minimal UI (add only if missing) -->
+<form id="prompt-form" style="margin:1rem 0;">
+  <textarea id="prompt-input" rows="5" style="width:100%;" placeholder="Type your task…"></textarea>
+  <button type="submit">Run fan-out</button>
+</form>
+<div id="results"></div>
+
+<script>
+  // Set this to the deployed Worker URL after deploy
+  window.JUSTASKING_PROXY = "https://YOUR-WORKER-SUBDOMAIN.workers.dev";
+
+  // Models to query via OpenRouter (edit as desired)
+  window.JUSTASKING_MODELS = [
+    "anthropic/claude-3.5-sonnet",
+    "openai/gpt-4.1",
+    "google/gemini-1.5-pro"
+  ];
+
+  async function fanoutPrompt(userText) {
+    const res = await fetch(`${window.JUSTASKING_PROXY}/fanout`, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({
+        task: userText,
+        system: "You are a specialist LLM for an engineering team. Be concise.",
+        models: window.JUSTASKING_MODELS
+      })
+    });
+    if (!res.ok) throw new Error(`Proxy error: ${res.status}`);
+    const { results } = await res.json();
+    return results; // [{model, content}, ...]
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const form = document.querySelector("#prompt-form");
+    const input = document.querySelector("#prompt-input");
+    const out = document.querySelector("#results");
+    if (!form || !input || !out) return;
+
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      out.textContent = "Running fan-out…";
+      try {
+        const results = await fanoutPrompt(input.value.trim());
+        out.innerHTML = results.map(r => (
+          `<section>
+             <h3>${r.model}</h3>
+             <pre style="white-space:pre-wrap">${r.content.replace(/</g,"&lt;")}</pre>
+           </section>`
+        )).join("<hr/>");
+      } catch (err) {
+        out.textContent = `Error: ${err.message}`;
+      }
+    });
+  });
+</script>
 </body>
 </html>

--- a/worker/worker.js
+++ b/worker/worker.js
@@ -1,0 +1,40 @@
+export default {
+  async fetch(req, env) {
+    const url = new URL(req.url);
+
+    if (req.method === "POST" && url.pathname === "/fanout") {
+      const { task, system, models } = await req.json();
+
+      const calls = models.map(async (model) => {
+        try {
+          const r = await fetch("https://openrouter.ai/api/v1/chat/completions", {
+            method: "POST",
+            headers: {
+              "Authorization": `Bearer ${env.OPENROUTER_API_KEY}`,
+              "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+              model,
+              messages: [
+                { role: "system", content: system || "You are a concise, helpful assistant." },
+                { role: "user", content: task }
+              ]
+            })
+          });
+          const j = await r.json();
+          const content = j?.choices?.[0]?.message?.content ?? "(no content)";
+          return { model, content };
+        } catch (e) {
+          return { model, content: `**ERROR:** ${e}` };
+        }
+      });
+
+      const results = await Promise.all(calls);
+      return new Response(JSON.stringify({ results }), {
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    return new Response("ok", { status: 200 });
+  }
+}

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,6 @@
+name = "justasking-proxy"
+main = "worker.js"
+compatibility_date = "2024-11-01"
+
+[observability]
+enabled = true


### PR DESCRIPTION
## Summary
- add a Cloudflare Worker that fans out chat completion requests to multiple OpenRouter models
- add Wrangler configuration for deploying the worker
- append a minimal fan-out form and client hook to the main index page

## Testing
- not run (not requested)

## Deployment Notes
- Deploy the Worker (team op):
  - From `worker/` dir (or CF dashboard):
    - `wrangler secret put OPENROUTER_API_KEY` → paste key
    - `wrangler deploy`
  - Copy the Worker URL and replace `window.JUSTASKING_PROXY` in `index.html`.
  - No API keys appear in repo or HTML.


------
https://chatgpt.com/codex/tasks/task_e_68d803a67fa4832c9a645d036b21de08